### PR TITLE
Disable libX11 specs

### DIFF
--- a/xorg/lib/libX11/Makefile
+++ b/xorg/lib/libX11/Makefile
@@ -44,6 +44,7 @@ define Build/Configure
 		--enable-xf86bigfont \
 		--without-xcb \
 		--without-launchd \
+		--disable-specs \
 	)
 endef
 


### PR DESCRIPTION
Compilation on Ubuntu 14.04 fails with a _groff_-related error ('table wider than line width').
Disabling the build of the spec docs looks like an acceptable workaround.
```
/usr/bin/groff -Tps -e -t -ms -dxV="libX11 1.3.2" -I. ../../specs/macros.t libX11.ms 2> index.libX11.ps.raw > libX11.ps
  table wider than line width
[...]
make[6]: *** [libX11.ps] Error 1
```