### PR TITLE
Fix missing dependency for libiconv.so.2

### DIFF
--- a/lib/qt4/Makefile
+++ b/lib/qt4/Makefile
@@ -64,7 +64,7 @@ endef
 
 define Package/qt4
   $(call Package/qt4/Default)
-  DEPENDS:=+zlib +librt +libstdcpp @!LINUX_2_4
+  DEPENDS:=+zlib +librt +libstdcpp +libiconv-full @!LINUX_2_4
 endef
 
 define Package/qt4-gui


### PR DESCRIPTION
The build sometimes failed with the following error: "Package qt4 is missing dependencies for the following libraries: libiconv.so.2".
This commit should fix the issue.